### PR TITLE
스테이징 서버를 위한 docker파일 작성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.git
+.idea
+.vscode
+*.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ coverage
 .idea
 .vscode
 *.log
+.env
+*.env
+src/configs/env/

--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,4 @@ DB_PASSWORD=your_password
 DB_DATABASE=maidb
 JWT_ACCESS_SECRET=your_jwt_access_secret
 JWT_REFRESH_SECRET=your_jwt_refresh_secret
-CORS_ORIGIN=http://localhost:3001
+CORS_ORIGIN=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,6 @@ DB_PASSWORD=your_password
 DB_DATABASE=maidb
 JWT_ACCESS_SECRET=your_jwt_access_secret
 JWT_REFRESH_SECRET=your_jwt_refresh_secret
+JWT_ACCESS_EXPIRATION_TIME=15m
+JWT_REFRESH_EXPIRATION_TIME=7d
 CORS_ORIGIN=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DB_HOST=host.docker.internal
+DB_PORT=5432
+DB_USERNAME=maidb
+DB_PASSWORD=your_password
+DB_DATABASE=maidb
+JWT_ACCESS_SECRET=your_jwt_access_secret
+JWT_REFRESH_SECRET=your_jwt_refresh_secret
+CORS_ORIGIN=http://localhost:3001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS production
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 3000
+
+CMD ["node", "dist/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,16 @@ FROM node:22-alpine AS production
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 COPY package*.json ./
 RUN npm ci --omit=dev
 
 COPY --from=builder /app/dist ./dist
 
+RUN chown -R node:node /app
+USER node
+
 EXPOSE 3000
 
-CMD ["node", "dist/main"]
+CMD ["node", "dist/main.js"]

--- a/README.md
+++ b/README.md
@@ -56,13 +56,19 @@ CORS_ORIGIN=http://localhost:3000
 
 > 호스트에 PostgreSQL이 설치되어 있는 경우를 기준으로 합니다.
 
+> **`.env` 파일 역할 구분**
+>
+> - `src/configs/env/.development.env` : 로컬 개발 시 앱이 직접 읽는 파일
+> - 프로젝트 루트 `.env` : Docker Compose가 컨테이너에 환경변수를 주입하기 위한 파일 (앱이 직접 읽지 않음)
+
 ### 사전 준비 (최초 1회)
 
 컨테이너에서 호스트 PostgreSQL로의 접속을 허용합니다.
 
 ```bash
 # /etc/postgresql/16/main/postgresql.conf
-listen_addresses = '*'
+# Docker 브리지 인터페이스(172.17.0.1)만 추가로 허용
+listen_addresses = 'localhost,172.17.0.1'
 
 # /etc/postgresql/16/main/pg_hba.conf 마지막 줄에 추가
 host  all  all  172.17.0.0/16  md5
@@ -74,11 +80,13 @@ sudo systemctl restart postgresql
 
 ### 실행
 
+마이그레이션은 컨테이너 이미지에 ts-node와 소스 파일이 포함되지 않으므로 호스트에서 실행합니다.
+
 ```bash
 git clone <레포 주소> && cd maiDB_backend
 cp .env.example .env  # 실제 값으로 수정
+npm i && npm run migration:run  # 호스트에서 마이그레이션 실행
 docker compose up -d --build
-docker compose exec app npm run migration:run
 ```
 
 ### 기타 명령어

--- a/README.md
+++ b/README.md
@@ -52,6 +52,46 @@ CORS_ORIGIN=http://localhost:3000
 
 <br>
 
+# Docker로 스테이징 환경 띄우기
+
+> 호스트에 PostgreSQL이 설치되어 있는 경우를 기준으로 합니다.
+
+### 사전 준비 (최초 1회)
+
+컨테이너에서 호스트 PostgreSQL로의 접속을 허용합니다.
+
+```bash
+# /etc/postgresql/16/main/postgresql.conf
+listen_addresses = '*'
+
+# /etc/postgresql/16/main/pg_hba.conf 마지막 줄에 추가
+host  all  all  172.17.0.0/16  md5
+```
+
+```bash
+sudo systemctl restart postgresql
+```
+
+### 실행
+
+```bash
+git clone <레포 주소> && cd maiDB_backend
+cp .env.example .env  # 실제 값으로 수정
+docker compose up -d --build
+docker compose exec app npm run migration:run
+```
+
+### 기타 명령어
+
+```bash
+docker compose ps            # 상태 확인
+docker compose logs app      # 로그 확인
+docker compose down          # 중지
+docker compose up -d --build # 코드 변경 후 재빌드
+```
+
+<br>
+
 # 마이그레이션 관련 스크립트
 
 본 프로젝트에선 TypeORM 마이그레이션을 사용하여 DB의 변경 내역을 관리합니다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     ports:
       - "3000:3000"
     env_file: .env
+    restart: unless-stopped
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    env_file: .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/src/configs/typeorm.config.ts
+++ b/src/configs/typeorm.config.ts
@@ -2,6 +2,7 @@ import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import * as dotenv from 'dotenv';
 import { DataSource } from 'typeorm';
 
+dotenv.config();
 dotenv.config({ path: 'src/configs/env/.development.env' });
 
 /**


### PR DESCRIPTION
## 목적
스테이징 서버 배포를 위한 Docker 환경 구성

## 처리방법
- `Dockerfile` 작성 (multi-stage 빌드로 이미지 경량화)
- `docker-compose.yml` 작성 (호스트 PostgreSQL 사용, `host.docker.internal`로 연결)
- `.env.example` 추가로 환경변수 템플릿 문서화
- `.dockerignore` 추가
- README에 Docker 스테이징 환경 세팅 가이드 추가

## 대응결과
`docker compose up -d --build` 로 스테이징 앱 서버 실행 가능