### PR TITLE
사용자 프로필이 언제 마지막으로 갱신되었는지, 언제 처음 등록되었는지 추가

### DIFF
--- a/src/migrations/1781369625181-AddProfileTimestamps.ts
+++ b/src/migrations/1781369625181-AddProfileTimestamps.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProfileTimestamps1781369625181 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "profiles" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "profiles" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "profiles" DROP COLUMN "updatedAt"`);
+        await queryRunner.query(`ALTER TABLE "profiles" DROP COLUMN "createdAt"`);
+    }
+}

--- a/src/profile/entities/profile.entity.ts
+++ b/src/profile/entities/profile.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryColumn, ManyToOne, JoinColumn } from "typeorm";
+import { Entity, Column, PrimaryColumn, ManyToOne, JoinColumn, CreateDateColumn, UpdateDateColumn } from "typeorm";
 import { User } from "src/user/entities/user.entity";
 import { Region } from "../enums/region.enum";
 
@@ -44,6 +44,12 @@ export class Profile {
 
     @Column({ nullable: false, default: 0 })
     starCount: number;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
 
     // User 엔티티와의 관계 설정 (외래 키)
     @ManyToOne(() => User, user => user.profiles, { nullable: false, onDelete: 'CASCADE' })


### PR DESCRIPTION
## 목적
프로필 엔티티에 생성/수정 시각 추적 필드 추가

## 처리방법
- `profile.entity.ts`에 TypeORM의 `@CreateDateColumn`, `@UpdateDateColumn` 데코레이터를 사용해 `createdAt`, `updatedAt` 필드 추가
- 마이그레이션 파일(`AddProfileTimestamps`) 작성 — `profiles` 테이블에 `createdAt`, `updatedAt` 컬럼을 `TIMESTAMP NOT NULL DEFAULT now()`로 추가하며, rollback 시 해당 컬럼을 제거하는 `down()` 로직도 포함

## 대응결과
프로필 레코드가 처음 생성된 시각과 마지막으로 수정된 시각이 DB에 자동 기록되며, 기존 데이터는 마이그레이션 실행 시 현재 시각을 기본값으로 채워짐